### PR TITLE
Downgrade MySQL to fix install issue on GKE

### DIFF
--- a/booksapp.yml
+++ b/booksapp.yml
@@ -189,7 +189,7 @@ spec:
     spec:
       containers:
       - name: mysql
-        image: mysql:5.7
+        image: mysql:5.6
         env:
         - name: MYSQL_ROOT_PASSWORD
           value: password


### PR DESCRIPTION
This fixes the issue described in docker-library/mysql/#69 in GKE. FWIW, the official GKE MySQL example also uses 5.6:

https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/a26e90eebf40f938e40647ca301047ae575fa16e/wordpress-persistent-disks/mysql.yaml#L18-L19