### PR TITLE
Skip mysql tzinfo setup, for faster startup

### DIFF
--- a/booksapp.yml
+++ b/booksapp.yml
@@ -188,6 +188,8 @@ spec:
           value: booksapp
         - name: MYSQL_PASSWORD
           value: booksapp
+        - name: MYSQL_INITDB_SKIP_TZINFO
+          value: "1"
         ports:
         - containerPort: 3306
           name: mysql


### PR DESCRIPTION
Signed-off-by: Andrew Seigner <siggy@buoyant.io>

Decreases `mysql` container startup time from 19s to 14s. Tested with an injected linkerd on Docker/K8s.
