### PR TITLE
Add k8s part-of label to all Deployments

### DIFF
--- a/booksapp-trafficsplit.yml
+++ b/booksapp-trafficsplit.yml
@@ -20,6 +20,7 @@ metadata:
   labels:
     app: mysql
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   selector:
     matchLabels:
@@ -109,6 +110,7 @@ metadata:
   labels:
     app: webapp
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   replicas: 3
   selector:
@@ -165,6 +167,7 @@ metadata:
   labels:
     app: authors
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   selector:
     matchLabels:
@@ -219,6 +222,7 @@ metadata:
   labels:
     app: books
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   selector:
     matchLabels:
@@ -258,6 +262,7 @@ metadata:
   labels:
     app: traffic
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   selector:
     matchLabels:
@@ -301,6 +306,7 @@ metadata:
   labels:
     app: authors-clone
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   selector:
     matchLabels:

--- a/booksapp.yml
+++ b/booksapp.yml
@@ -15,14 +15,19 @@ spec:
     port: 7000
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: webapp
   labels:
     app: webapp
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: webapp
+      project: booksapp
   template:
     metadata:
       labels:
@@ -65,14 +70,19 @@ spec:
     port: 7001
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: authors
   labels:
     app: authors
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: authors
+      project: booksapp
   template:
     metadata:
       labels:
@@ -115,14 +125,19 @@ spec:
     port: 7002
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: books
   labels:
     app: books
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: books
+      project: booksapp
   template:
     metadata:
       labels:
@@ -148,14 +163,19 @@ spec:
           containerPort: 7002
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: traffic
   labels:
     app: traffic
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: traffic
+      project: booksapp
   template:
     metadata:
       labels:

--- a/k8s/mysql-app.yml
+++ b/k8s/mysql-app.yml
@@ -21,6 +21,7 @@ metadata:
   labels:
     app: webapp
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   replicas: 3
   template:
@@ -71,6 +72,7 @@ metadata:
   labels:
     app: authors
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   replicas: 3
   template:
@@ -121,6 +123,7 @@ metadata:
   labels:
     app: books
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   replicas: 3
   template:
@@ -154,6 +157,7 @@ metadata:
   labels:
     app: traffic
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   replicas: 1
   template:

--- a/k8s/mysql-backend.yml
+++ b/k8s/mysql-backend.yml
@@ -20,6 +20,7 @@ metadata:
   labels:
     app: mysql
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   selector:
     matchLabels:

--- a/k8s/mysql-chaos.yml
+++ b/k8s/mysql-chaos.yml
@@ -64,6 +64,7 @@ metadata:
   labels:
     app: chaos
     project: booksapp
+    app.kubernetes.io/part-of: booksapp
 spec:
   replicas: 1
   template:


### PR DESCRIPTION
Also update resource group and selectors to match linkerd/website repo.

Relates to linkerd/website#512 and linkerd/website#660

Signed-off-by: Andrew Seigner <siggy@buoyant.io>