### PR TITLE
give all booksapp deployments separate serviceaccounts

### DIFF
--- a/booksapp.yml
+++ b/booksapp.yml
@@ -14,6 +14,14 @@ spec:
   - name: service
     port: 7000
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: webapp
+  labels:
+    app: webapp
+    project: booksapp
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -24,7 +32,7 @@ metadata:
 spec:
   replicas: 3
   selector:
-    matchLabels:      
+    matchLabels:
       app: webapp
       project: booksapp
   template:
@@ -33,6 +41,7 @@ spec:
         app: webapp
         project: booksapp
     spec:
+      serviceAccountName: webapp
       dnsPolicy: ClusterFirst
       containers:
       - name: service
@@ -67,6 +76,14 @@ spec:
   - name: service
     port: 7001
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: authors
+  labels:
+    app: authors
+    project: booksapp
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -87,6 +104,7 @@ spec:
         project: booksapp
     spec:
       dnsPolicy: ClusterFirst
+      serviceAccountName: authors
       containers:
       - name: service
         image: buoyantio/booksapp:v0.0.5
@@ -120,6 +138,14 @@ spec:
   - name: service
     port: 7002
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: books
+  labels:
+    app: books
+    project: booksapp
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -140,6 +166,7 @@ spec:
         project: booksapp
     spec:
       dnsPolicy: ClusterFirst
+      serviceAccountName: books
       containers:
       - name: service
         image: buoyantio/booksapp:v0.0.5
@@ -156,6 +183,14 @@ spec:
         ports:
         - name: service
           containerPort: 7002
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: traffic
+  labels:
+    app: traffic
+    project: booksapp
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -177,6 +212,7 @@ spec:
         project: booksapp
     spec:
       dnsPolicy: ClusterFirst
+      serviceAccountName: traffic
       containers:
       - name: traffic
         image: buoyantio/booksapp-traffic:v0.0.3


### PR DESCRIPTION
This commit changes the Kubernetes manifests in `booksapp.yml` to give
each deployment (`books`, `authors`, `webapp`, and `traffic`) its own
ServiceAccount, rather than creating all the deployments with the
default ServiceAccount. This makes it possible to use `booksapp` to
demonstrate fine-grained authorization policy with Linkerd.